### PR TITLE
Make `npm run dev` use PORT environment variable (like `npm run start` does)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,9 +266,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
-      "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types%2freact/-/react-17.0.0.tgz",
+      "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@calvium/prettier-config": "1.0.1",
     "@types/node": "^14.14.9",
-    "@types/react": "^16.14.0",
+    "@types/react": "^17.0.0",
     "autoprefixer": "^10.0.2",
     "postcss": "8.2.1",
     "prettier": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "dev": "NODE_OPTIONS='--inspect' next dev",
+    "dev": "NODE_OPTIONS='--inspect' next dev -p ${PORT:-3000}",
     "build": "next build",
     "start": "next start"
   },


### PR DESCRIPTION
- Let you `env PORT=3001 npm run dev` just like how you can `env PORT=3001 npm run start`
- While I'm here, also bump @types/react so we're using a version of the React types that is more similar to the version of React which we're using.